### PR TITLE
#176 icons toelaten in custom nav header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # C extensions
 *.so
+*DS_Store
 
 # Packages
 *.egg

--- a/pyoes/templates/pyoes/header.jinja2
+++ b/pyoes/templates/pyoes/header.jinja2
@@ -76,7 +76,7 @@
             {% if id == 'home' %}
               <a href="{{ href }}"><i class="fa fa-home"></i></a>
             {% else %}
-              <a href="{{ href }}">{{ caption }}</a>
+              <a href="{{ href }}">{{ caption|safe }}</a>
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
- .gitignore: DS_Store ignore voor MacOS mappen
- caption|safe toegevoegd

closes #176 